### PR TITLE
Implement custom modal dialogs

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -484,15 +484,15 @@ async function startBibtex() {
             const obj = Object.assign({construct: '', axis: '', methodology_supported: '', relevance: ''}, en);
             obj.entry_type = en.entry_type || defaultType || (en.journal ? 'article' : 'book');
             if (!obj.construct) {
-                const v = prompt(`Construct for "${obj.title}"?`);
+                const v = await showPrompt(`Construct for "${obj.title}"?`);
                 if (v !== null) obj.construct = v.trim();
             }
             if (!obj.axis) {
-                const v = prompt(`Axis for "${obj.title}"?`);
+                const v = await showPrompt(`Axis for "${obj.title}"?`);
                 if (v !== null) obj.axis = v.trim();
             }
             if (!obj.methodology_supported) {
-                const v = prompt(`Methodology supported for "${obj.title}"?`);
+                const v = await showPrompt(`Methodology supported for "${obj.title}"?`);
                 if (v !== null) obj.methodology_supported = v.trim();
             }
             obj.__index = ++maxIndex;
@@ -591,7 +591,7 @@ async function startAddLit() {
         const constructVal = e.target.construct.value.trim();
         const methVal = e.target.methodology_supported.value.trim();
         if (axisArr.length === 0 && !constructVal && !methVal) {
-            alert('Please specify at least one of Axis, Construct, or Methodology Supported.');
+            showToast('Please specify at least one of Axis, Construct, or Methodology Supported.');
             return;
         }
         const authorArr = Array.from(form.querySelectorAll('.author-input'))
@@ -623,7 +623,7 @@ async function startAddLit() {
             return t === titleLower || (doiLower && d === doiLower);
         });
         if (exists) {
-            alert('This entry already exists.');
+            showToast('This entry already exists.');
             return;
         }
         if (typeof addLiterature === 'function') {
@@ -657,7 +657,7 @@ async function startAddLit() {
 
 async function startEditLit() {
     if (!authed) { if (!(await authenticate())) return; authed = true; }
-    if (selectedLitId === null) { alert('Select an entry first.'); return; }
+    if (selectedLitId === null) { showToast('Select an entry first.'); return; }
     const item = literature.find(l => (l.id ?? l.__index) == selectedLitId);
     if (!item) return;
     const axisVals = Array.isArray(item.axis) ? item.axis : (item.axis || '').split(',').map(a=>a.trim());
@@ -737,7 +737,7 @@ async function startEditLit() {
     form.addEventListener('submit', async e => {
         e.preventDefault();
         if (!authed) { if (!(await authenticate())) return; authed = true; }
-        if (!confirm('Save changes?')) return;
+        if (!(await showConfirm('Save changes?'))) return;
         const before = JSON.parse(JSON.stringify(item));
         item.title = toTitleCase(form.title.value.trim());
         const authorInputs = Array.from(form.querySelectorAll('.author-input'))
@@ -790,11 +790,11 @@ async function startEditLit() {
 }
 
 async function deleteSelectedLit() {
-    if (selectedLitId === null) { alert('Select an entry first.'); return; }
+    if (selectedLitId === null) { showToast('Select an entry first.'); return; }
     const idx = literature.findIndex(l => (l.id ?? l.__index) == selectedLitId);
     if (idx === -1) return;
     if (!authed) { if (!(await authenticate())) return; authed = true; }
-    if (!confirm('Delete this entry?')) return;
+    if (!(await showConfirm('Delete this entry?'))) return;
     const item = literature[idx];
     if (item.id && typeof deleteLiterature === 'function') await deleteLiterature(item.id);
     const removed = literature.splice(idx,1)[0];
@@ -804,7 +804,7 @@ async function deleteSelectedLit() {
 }
 
 async function undoLastLitAction() {
-    if (!lastLitAction) { alert('Nothing to undo'); return; }
+    if (!lastLitAction) { showToast('Nothing to undo'); return; }
     const { type, item, index, before } = lastLitAction;
     if (type === 'add') {
         if (item.id && typeof deleteLiterature === 'function') await deleteLiterature(item.id);
@@ -833,8 +833,8 @@ document.getElementById('bibtex-btn').addEventListener('click', startBibtex);
 // document.getElementById('undo-lit-btn').addEventListener('click', undoLastLitAction);
 
 // Confirm before saving new or updated literature
-document.getElementById('literature-form')?.addEventListener('submit', e => {
-    if (!confirm('Save changes?')) {
+document.getElementById('literature-form')?.addEventListener('submit', async e => {
+    if (!(await showConfirm('Save changes?'))) {
         e.preventDefault();
     }
 });

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -454,7 +454,7 @@ async function startAddConstruct() {
 
 async function startEditConstruct() {
     if (!authed) { if (!(await authenticate())) return; authed = true; }
-    if (selectedConstructId === null) { alert('Select an entry first.'); return; }
+    if (selectedConstructId === null) { showToast('Select an entry first.'); return; }
     const item = constructs.find(c => (c.id ?? c.__index) == selectedConstructId);
     if (!item) return;
     const axesVals = Array.isArray(item.axes) ? item.axes : (item.axes || '').split(',').map(a=>a.trim());
@@ -494,7 +494,7 @@ async function startEditConstruct() {
     form.addEventListener('submit', async e => {
         e.preventDefault();
         if (!authed) { if (!(await authenticate())) return; authed = true; }
-        if (!confirm('Save changes?')) return;
+        if (!(await showConfirm('Save changes?'))) return;
         const axesArr = Array.from(form.elements.axes.selectedOptions).map(o => o.value);
         const refsArr = Array.from(form.elements.references.selectedOptions).map(o => o.value);
         const catArrEdit = Array.from(form.elements.category.selectedOptions).map(o => o.value);
@@ -532,11 +532,11 @@ async function startEditConstruct() {
 }
 
 async function deleteSelectedConstruct() {
-    if (selectedConstructId === null) { alert('Select an entry first.'); return; }
+    if (selectedConstructId === null) { showToast('Select an entry first.'); return; }
     const idx = constructs.findIndex(c => (c.id ?? c.__index) == selectedConstructId);
     if (idx === -1) return;
     if (!authed) { if (!(await authenticate())) return; authed = true; }
-    if (!confirm('Delete this construct?')) return;
+    if (!(await showConfirm('Delete this construct?'))) return;
     const item = constructs[idx];
     if (item.id && typeof deleteConstruct === 'function') await deleteConstruct(item.id);
     constructs.splice(idx,1);
@@ -550,8 +550,8 @@ document.getElementById('delete-construct-btn').addEventListener('click', delete
 document.getElementById('add-construct-btn').addEventListener('click', startAddConstruct);
 
 // Confirm before saving new or updated constructs
-document.getElementById('construct-form')?.addEventListener('submit', e => {
-    if (!confirm('Save changes?')) {
+document.getElementById('construct-form')?.addEventListener('submit', async e => {
+    if (!(await showConfirm('Save changes?'))) {
         e.preventDefault();
     }
 });

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -208,7 +208,7 @@
 
     async function startEditBenchmark() {
         if (!authed) { if (!(await authenticate())) return; authed = true; }
-        if (selectedBenchmarkId === null) { alert('Select an entry first.'); return; }
+        if (selectedBenchmarkId === null) { showToast('Select an entry first.'); return; }
         const item = benchmarks.find(b => (b.id ?? b.__index) == selectedBenchmarkId);
         if (!item) return;
         const formHtml = `<form id="benchmark-edit-form">
@@ -258,11 +258,11 @@
     }
 
     async function deleteSelectedBenchmark() {
-        if (selectedBenchmarkId === null) { alert('Select an entry first.'); return; }
+        if (selectedBenchmarkId === null) { showToast('Select an entry first.'); return; }
         const idx = benchmarks.findIndex(b => (b.id ?? b.__index) == selectedBenchmarkId);
         if (idx === -1) return;
         if (!authed) { if (!(await authenticate())) return; authed = true; }
-        if (!confirm('Delete this benchmark?')) return;
+        if (!(await showConfirm('Delete this benchmark?'))) return;
         const item = benchmarks[idx];
         if (item.id && typeof deleteBenchmark === 'function') await deleteBenchmark(item.id);
         const removed = benchmarks.splice(idx,1)[0];
@@ -272,7 +272,7 @@
     }
 
     async function undoLastBenchmarkAction() {
-        if (!lastBmAction) { alert('Nothing to undo'); return; }
+        if (!lastBmAction) { showToast('Nothing to undo'); return; }
         const { type, item, index, before } = lastBmAction;
         if (type === 'add') {
             if (item.id && typeof deleteBenchmark === 'function') await deleteBenchmark(item.id);

--- a/docs/script.js
+++ b/docs/script.js
@@ -147,6 +147,69 @@ function showToast(message, duration = 3000) {
   }, duration);
 }
 
+function showConfirm(message, trigger = document.activeElement) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.innerHTML = `
+      <div class="modal-box">
+        <p>${message}</p>
+        <div class="modal-buttons">
+          <button type="button" class="button" id="confirm-ok">OK</button>
+          <button type="button" class="button" id="confirm-cancel">Cancel</button>
+        </div>
+      </div>`;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    document.body.appendChild(overlay);
+    const ok = overlay.querySelector('#confirm-ok');
+    const cancel = overlay.querySelector('#confirm-cancel');
+    ok.focus();
+    const cleanup = (val) => {
+      overlay.remove();
+      document.removeEventListener('keydown', onKey);
+      if (trigger && typeof trigger.focus === 'function') trigger.focus();
+      resolve(val);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') cleanup(false); };
+    document.addEventListener('keydown', onKey);
+    ok.addEventListener('click', () => cleanup(true));
+    cancel.addEventListener('click', () => cleanup(false));
+  });
+}
+
+function showPrompt(message, defaultValue = '', trigger = document.activeElement) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.innerHTML = `
+      <form class="modal-box" id="prompt-form">
+        <label>${message}<br><input type="text" id="prompt-input"></label>
+        <div class="modal-buttons">
+          <button type="submit" class="button">OK</button>
+          <button type="button" class="button" id="prompt-cancel">Cancel</button>
+        </div>
+      </form>`;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    document.body.appendChild(overlay);
+    const form = overlay.querySelector('#prompt-form');
+    const input = overlay.querySelector('#prompt-input');
+    input.value = defaultValue;
+    input.focus();
+    const cleanup = (val) => {
+      overlay.remove();
+      document.removeEventListener('keydown', onKey);
+      if (trigger && typeof trigger.focus === 'function') trigger.focus();
+      resolve(val);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') cleanup(null); };
+    document.addEventListener('keydown', onKey);
+    form.addEventListener('submit', e => { e.preventDefault(); cleanup(input.value); });
+    overlay.querySelector('#prompt-cancel').addEventListener('click', () => cleanup(null));
+  });
+}
+
 function toTitleCase(str) {
   return str.replace(/\b(\w)(\w*)/g, (_, c, rest) => c.toUpperCase() + rest.toLowerCase());
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -553,12 +553,44 @@ tbody tr:nth-child(even) {
     display: flex;
     gap: 0.5rem;
 }
+
+/* Generic modal overlay for confirmation and prompts */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-overlay .modal-box {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    max-width: 300px;
+    width: 90%;
+}
+
+.modal-overlay .modal-buttons {
+    margin-top: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+}
 @media (prefers-color-scheme: dark) {
     #login-overlay form {
         background: #222;
         color: #eee;
     }
     #edit-overlay form {
+        background: #222;
+        color: #eee;
+    }
+    .modal-overlay .modal-box {
         background: #222;
         color: #eee;
     }


### PR DESCRIPTION
## Summary
- add `showConfirm` and `showPrompt` helpers
- style generic modal overlay
- swap alert/prompt/confirm with new helpers across Phase pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c287f72c8322b929e734359fdcfe