### PR TITLE
Remove reloads from Phase 2 page

### DIFF
--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -445,7 +445,6 @@ async function startAddConstruct() {
         constructs.push(obj);
         addRow.remove();
         applyConstructFilters();
-        window.location.reload();
     });
     document.getElementById('construct-add-cancel').addEventListener('click', () => addRow.remove());
 }
@@ -526,7 +525,6 @@ async function startEditConstruct() {
         });
         hideEditOverlay();
         applyConstructFilters();
-        window.location.reload();
     });
     document.getElementById('construct-edit-cancel').addEventListener('click', hideEditOverlay);
 }
@@ -542,7 +540,6 @@ async function deleteSelectedConstruct() {
     constructs.splice(idx,1);
     selectedConstructId = null;
     applyConstructFilters();
-    window.location.reload();
 }
 
 document.getElementById('edit-construct-btn').addEventListener('click', startEditConstruct);


### PR DESCRIPTION
## Summary
- update `phase2.html` to rely on DOM updates instead of page reloads when adding, editing or deleting constructs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842c3e113c883228f0c875af2d47531