### PR TITLE
Remove hard-coded supabase secrets

### DIFF
--- a/.github/workflows/export_constructs.yml
+++ b/.github/workflows/export_constructs.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create env.js
         run: |
-          echo "window.SUPABASE_URL = '${SUPABASE_URL}';" > docs/env.js
-          echo "window.SUPABASE_ANON_KEY = '${SUPABASE_ANON_KEY}';" >> docs/env.js
+          node docs/env.js > docs/env.tmp.js
+          mv docs/env.tmp.js docs/env.js
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/.github/workflows/export_references.yml
+++ b/.github/workflows/export_references.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create env.js
         run: |
-          echo "window.SUPABASE_URL = '${SUPABASE_URL}';" > docs/env.js
-          echo "window.SUPABASE_ANON_KEY = '${SUPABASE_ANON_KEY}';" >> docs/env.js
+          node docs/env.js > docs/env.tmp.js
+          mv docs/env.tmp.js docs/env.js
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/docs/env.js
+++ b/docs/env.js
@@ -1,2 +1,12 @@
-window.SUPABASE_URL = 'https://pzmmgpzcnjhivkizcvpp.supabase.co';
-window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB6bW1ncHpjbmpoaXZraXpjdnBwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg2MzA4ODEsImV4cCI6MjA2NDIwNjg4MX0.oeXfuk-Z2_BS4M7jU9vguedalcuw217gRRvxlg2t9Hc';
+// Build-time script to generate Supabase client config without storing secrets.
+
+const url = process.env.SUPABASE_URL || '';
+const anon = process.env.SUPABASE_ANON_KEY || '';
+
+const output = `window.SUPABASE_URL = '${url}';\nwindow.SUPABASE_ANON_KEY = '${anon}';\n`;
+
+if (require.main === module) {
+  process.stdout.write(output);
+}
+
+module.exports = output;

--- a/docs/supabase_setup.md
+++ b/docs/supabase_setup.md
@@ -29,6 +29,18 @@ export SUPABASE_SERVICE_KEY="<service role key>"
 node scripts/upload_to_supabase.js
 ```
 
+## Website environment variables
+
+The website reads Supabase using a small `env.js` file generated at build time.
+Set the following variables in your shell (or as repository secrets) so the
+deployment workflow can create this file without storing credentials in the
+repository:
+
+```bash
+export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_ANON_KEY="<public anon key>"
+```
+
 The script reads `data/construct_submissions.json` and `data/literature.json` and inserts them into the `constructs` and `literature` tables. You can also pass a file and table name explicitly:
 
 ```bash


### PR DESCRIPTION
## Summary
- load Supabase credentials from environment variables
- add website env var docs
- generate env.js during deployment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c4ed46888322b3e9f26c3c1b953b