### PR TITLE
Improve BibTeX upload error feedback

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -499,8 +499,16 @@ async function startBibtex() {
             if (authed && typeof addLiterature === 'function') {
                 try {
                     const { data, error } = await addLiterature(obj);
-                    if (!error && data && data[0]) Object.assign(obj, data[0]);
-                } catch (err) { console.error(err); }
+                    if (error) {
+                        console.error(error);
+                        showToast(`Upload failed: ${error.message || error}`);
+                    } else if (data && data[0]) {
+                        Object.assign(obj, data[0]);
+                    }
+                } catch (err) {
+                    console.error(err);
+                    showToast(`Upload failed: ${err.message || err}`);
+                }
             }
             literature.push(obj);
             titles.add(t);


### PR DESCRIPTION
## Summary
- show toast notification when adding literature via BibTeX import fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d539699083228639cfbd6e708e25