### PR TITLE
Fix client-side pushes on database errors

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -496,24 +496,29 @@ async function startBibtex() {
                 if (v !== null) obj.methodology_supported = v.trim();
             }
             obj.__index = ++maxIndex;
+            let success = true;
             if (authed && typeof addLiterature === 'function') {
                 try {
                     const { data, error } = await addLiterature(obj);
                     if (error) {
                         console.error(error);
                         showToast(`Upload failed: ${error.message || error}`);
+                        success = false;
                     } else if (data && data[0]) {
                         Object.assign(obj, data[0]);
                     }
                 } catch (err) {
                     console.error(err);
                     showToast(`Upload failed: ${err.message || err}`);
+                    success = false;
                 }
             }
-            literature.push(obj);
-            titles.add(t);
-            if (d) dois.add(d);
-            added++;
+            if (success) {
+                literature.push(obj);
+                titles.add(t);
+                if (d) dois.add(d);
+                added++;
+            }
         }
         applyLitFilters();
         showToast(added ? `${added} entries added` : 'No new entries added');
@@ -634,22 +639,25 @@ async function startAddLit() {
             showToast('This entry already exists.');
             return;
         }
+        let success = true;
         if (typeof addLiterature === 'function') {
             try {
                 const { data, error } = await addLiterature(obj);
                 if (error) {
                     errorDiv.textContent = error.message || error;
                     errorDiv.style.display = 'block';
-                    return;
+                    success = false;
+                } else if (data && data[0]) {
+                    Object.assign(obj, data[0]);
                 }
-                if (data && data[0]) Object.assign(obj, data[0]);
             } catch (err) {
                 console.error(err);
                 errorDiv.textContent = err.message || err;
                 errorDiv.style.display = 'block';
-                return;
+                success = false;
             }
         }
+        if (!success) return;
         obj.axis = axisArr.join(', ');
         obj.__index = Math.max(0, ...literature.map(l => l.__index || 0)) + 1;
         literature.push(obj);

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -424,22 +424,25 @@ async function startAddConstruct() {
             verification_issues: e.target.verification_issues.value,
             category: catArr.join(', ')
         };
+        let success = true;
         if (typeof addConstruct === 'function') {
             try {
                 const { data, error } = await addConstruct(obj);
                 if (error) {
                     errorDiv.textContent = error.message || error;
                     errorDiv.style.display = 'block';
-                    return;
+                    success = false;
+                } else if (data && data[0]) {
+                    Object.assign(obj, data[0]);
                 }
-                if (data && data[0]) Object.assign(obj, data[0]);
             } catch (err) {
                 console.error(err);
                 errorDiv.textContent = err.message || err;
                 errorDiv.style.display = 'block';
-                return;
+                success = false;
             }
         }
+        if (!success) return;
         obj.axis = axesArr.join(', ');
         obj.__index = Math.max(0, ...constructs.map(c => c.__index || 0)) + 1;
         constructs.push(obj);

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -190,13 +190,25 @@
                 difficulty_level: parseInt(form.difficulty_level.value,10) || null,
                 notes: form.notes.value
             };
+            let success = true;
             if (typeof addBenchmark === 'function') {
                 try {
                     const { data, error } = await addBenchmark(obj);
-                    if (error) { errorDiv.textContent = error.message || error; errorDiv.style.display='block'; return; }
-                    if (data && data[0]) Object.assign(obj, data[0]);
-                } catch(err) { console.error(err); errorDiv.textContent = err.message || err; errorDiv.style.display='block'; return; }
+                    if (error) {
+                        errorDiv.textContent = error.message || error;
+                        errorDiv.style.display='block';
+                        success = false;
+                    } else if (data && data[0]) {
+                        Object.assign(obj, data[0]);
+                    }
+                } catch(err) {
+                    console.error(err);
+                    errorDiv.textContent = err.message || err;
+                    errorDiv.style.display='block';
+                    success = false;
+                }
             }
+            if (!success) return;
             obj.__index = Math.max(0,...benchmarks.map(b=>b.__index||0))+1;
             benchmarks.push(obj);
             row.remove();


### PR DESCRIPTION
## Summary
- protect batch BibTeX/CSV upload in phase1 from invalid pushes when DB insert fails
- keep manual "Add Source" entry open when Supabase insertion fails
- gate construct and benchmark additions on successful DB writes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d839b5d48322936473775ce0be35