### PR TITLE
Restore page reload after entry changes

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -664,6 +664,7 @@ async function startAddLit() {
         addRow.remove();
         applyLitFilters();
         showToast('Entry added');
+        window.location.reload();
         lastLitAction = { type: 'add', item: obj, index: literature.length - 1 };
     });
     document.getElementById('lit-add-cancel').addEventListener('click', () => {
@@ -800,6 +801,7 @@ async function startEditLit() {
         hideEditOverlay();
         applyLitFilters();
         showToast('Entry updated');
+        window.location.reload();
         lastLitAction = { type: 'update', item, before };
     });
     document.getElementById('lit-edit-cancel').addEventListener('click', hideEditOverlay);
@@ -816,6 +818,7 @@ async function deleteSelectedLit() {
     const removed = literature.splice(idx,1)[0];
     selectedLitId = null;
     applyLitFilters();
+    window.location.reload();
     lastLitAction = { type: 'delete', item: removed, index: idx };
 }
 

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -213,6 +213,7 @@
             benchmarks.push(obj);
             row.remove();
             renderBenchmarks(benchmarks);
+            window.location.reload();
             lastBmAction = { type: 'add', item: obj, index: benchmarks.length - 1 };
         });
         document.getElementById('benchmark-add-cancel').addEventListener('click',()=>row.remove());
@@ -264,6 +265,7 @@
             }
             hideEditOverlay();
             renderBenchmarks(benchmarks);
+            window.location.reload();
             lastBmAction = { type: 'update', item, before };
         });
         document.getElementById('benchmark-edit-cancel').addEventListener('click', hideEditOverlay);
@@ -280,6 +282,7 @@
         const removed = benchmarks.splice(idx,1)[0];
         selectedBenchmarkId = null;
         renderBenchmarks(benchmarks);
+        window.location.reload();
         lastBmAction = { type: 'delete', item: removed, index: idx };
     }
 


### PR DESCRIPTION
## Summary
- reload Phase 1 page when literature entries are added, updated or deleted
- reload Phase 3 page when benchmark entries are added, updated or deleted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ddbca2bc83228b257372aab97f9e