### PR TITLE
Fix license header

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT LicenseAdd commentMore actions
+MIT License
 
 Copyright (c) 2025 AI EQ Research Collaborative
 


### PR DESCRIPTION
## Summary
- remove stray text so the license begins with 'MIT License'

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845cde27100832292ceb2ec86a2813e