### PR TITLE
Add licensing notes

### DIFF
--- a/LICENSE-NOTES.md
+++ b/LICENSE-NOTES.md
@@ -1,0 +1,8 @@
+# License Notes
+
+This repository's source code and documentation are released under the [MIT License](LICENSE).
+
+However, the final evaluation rubric and test prompts referenced in this project are privately maintained by a steward organization (for example, ML Commons) and are **not** covered by the MIT License. Access to those materials may be restricted and subject to separate terms.
+
+References to third-party datasets or tools in this repository retain their respective licenses as provided by the original sources.
+

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) and our [CODE_OF_CONDUCT.md](CODE
 </p>
 
 ## License
-- **Code and documentation**: Released under the [MIT License](LICENSE). See [LICENSE-NOTES.md](LICENSE-NOTES.md) for additional details.
+- **Code and documentation**: Released under the [MIT License](LICENSE). See [LICENSE-NOTES.md](LICENSE-NOTES.md) for details on the private evaluation rubric.


### PR DESCRIPTION
## Summary
- document license nuances in new `LICENSE-NOTES.md`
- link the new notes in the README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cdefd5a08322aa345bb84d541dfb