### PR TITLE
Update docs for collaborator order and independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This website serves as the foundational resource and single source of truth for 
 
 This benchmark is organized as a **community-led initiative**. Once the framework is stable, long-term stewardship will transition to **ML Commons** to ensure broad, vendor-neutral oversight.
 
+Although funding and resources may come from a range of academic and industry partners, the research team retains full independence in methodology and analysis. Our goal is to produce an unbiased, gold‑standard EQ benchmark through open, interdisciplinary collaboration.
+
 Status: *early scaffold* (v0.0.1) - layout may change
 
 New to these terms? See the [Glossary](docs/glossary.md) for quick definitions.

--- a/docs/adapt.html
+++ b/docs/adapt.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/alternative-models.html
+++ b/docs/alternative-models.html
@@ -81,7 +81,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/axes.html
+++ b/docs/axes.html
@@ -109,7 +109,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/ethics/ai_emotional_intelligence_benchmark_consent.md
+++ b/docs/ethics/ai_emotional_intelligence_benchmark_consent.md
@@ -5,6 +5,7 @@
 **Project Lead:** Max Parks
 **Affiliation:** University of Michigan–Flint  
 **Funding Provided By:** Inflection AI
+**Research independence:** Funding sources do not influence methods or reporting; our interdisciplinary team strives for an unbiased, gold-standard EQ benchmark.
 **Collaborator:** Mark Allison, Department of Computer Science, University of Michigan–Flint
 **Version:** v0.1 | Drafted June 4, 2025
 

--- a/docs/expert-collaborators.html
+++ b/docs/expert-collaborators.html
@@ -34,6 +34,7 @@
         <section>
             <h1>Collaborators</h1>
             <ul>
+                <li>Max Parks – Project Lead and coordination point</li>
                 <li>Sean White – Inflection AI</li>
                 <li>Kheli Atluru – Project Manager</li>
                 <li>Ali Pickover – WaveLife</li>
@@ -42,15 +43,15 @@
                 <li>Sarah Adler – Psychologist and CEO of Wave.io</li>
                 <li>Meera Vinod – Expert in Machine Learning and AI</li>
                 <li>Wendy Ju – Cornell University</li>
-                <li>Max Parks – Project Lead and coordination point</li>
             </ul>
+            <p class="funding-note">Funding is provided by various partners, but our interdisciplinary team remains unbiased and is dedicated to producing the gold standard EQ benchmark framework.</p>
             <h2>Contact</h2>
             <p>For questions about the AI EQ Research Hub, email the project lead <a href="mailto:maxaeonparks@gmail.com">Max Parks</a>.</p>
         </section>
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/explain.html
+++ b/docs/explain.html
@@ -55,7 +55,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/extended.html
+++ b/docs/extended.html
@@ -55,7 +55,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,9 @@
             Our interdisciplinary team will collaboratively identify, measure, and validate essential constructs across various levels of human-AI interaction.
           </p>
           <p>
+            Although funded by a variety of partners, the project maintains independent oversight. Our aim is to produce a gold standard EQ benchmark through unbiased, interdisciplinary collaboration.
+          </p>
+          <p>
             We are currently in <strong>Phase 1</strong>: Initial literature review and first pass construct identification.
           </p>
         </section>
@@ -71,7 +74,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="env.js"></script>
     <script src="script.js"></script>

--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -130,7 +130,7 @@
 
     </main>
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script>
 

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -102,7 +102,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script>
     let constructs = [];

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -85,7 +85,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script>
     let benchmarks = [];

--- a/docs/phase4.html
+++ b/docs/phase4.html
@@ -107,7 +107,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/research.html
+++ b/docs/research.html
@@ -129,7 +129,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/respond.html
+++ b/docs/respond.html
@@ -52,7 +52,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/sense.html
+++ b/docs/sense.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; AI EQ Research Collaborative</p>
+        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
     </footer>
     <script src="script.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- reorder collaborators with Max Parks at top
- note funding-independent research approach in several docs
- link all copyright footers to the collaborators page

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684799ec28cc8322ab5a7bc416aad97d