### PR TITLE
Update license and remove old attribution

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 AI EQ Research Collaborative
+Copyright (c) 2025 Max Parks
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,5 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-The benchmark code and documentation in this repository are licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) and our [CODE_OF_CONDUCT.md](CODE
 </p>
 
 ## License
-- **Code and documentation**: Released under the [MIT License](LICENSE). See [LICENSE-NOTES.md](LICENSE-NOTES.md) for details on the private evaluation rubric.
+- **Code and documentation**: Released under the [MIT License](LICENSE.md). See [LICENSE-NOTES.md](LICENSE-NOTES.md) for details on the private evaluation rubric.

--- a/docs/adapt.html
+++ b/docs/adapt.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/alternative-models.html
+++ b/docs/alternative-models.html
@@ -81,7 +81,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/axes.html
+++ b/docs/axes.html
@@ -115,7 +115,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/expert-collaborators.html
+++ b/docs/expert-collaborators.html
@@ -51,7 +51,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/explain.html
+++ b/docs/explain.html
@@ -55,7 +55,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/extended.html
+++ b/docs/extended.html
@@ -61,7 +61,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="env.js"></script>
     <script src="script.js"></script>

--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -130,7 +130,7 @@
 
     </main>
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script>
 

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -102,7 +102,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script>
     let constructs = [];

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -85,7 +85,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script>
     let benchmarks = [];

--- a/docs/phase4.html
+++ b/docs/phase4.html
@@ -107,7 +107,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/research.html
+++ b/docs/research.html
@@ -129,7 +129,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/respond.html
+++ b/docs/respond.html
@@ -52,7 +52,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/sense.html
+++ b/docs/sense.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; <a href="expert-collaborators.html">AI EQ Research Collaborative</a></p>
+        <p>&copy; Max Parks</p>
     </footer>
     <script src="script.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- replace license with MIT license credited to Max Parks
- update README to point to `LICENSE.md`
- remove "AI EQ Research Collaborative" attribution from HTML docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850c08d1cc08322813e8483ce067703