### PR TITLE
Add evaluation prompt docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,7 @@
                     </ul>
                 </li>
                 <li><a href="expert-collaborators.html">Collaborators</a></li>
+                <li><a href="prompt-development.html">Evaluation Prompt Development</a></li>
                 <li><a href="https://github.com/maxaeon/EQ-bench">GitHub Repository</a></li>
             </ul>
         </nav>

--- a/docs/prompt-development.md
+++ b/docs/prompt-development.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Evaluation Prompt Development
+---
+
+# Evaluation Prompt Development
+
+This document outlines how evaluation prompts are designed for the EQ benchmark. Each prompt is explicitly aligned with one or more SERA-X constructs so that responses can be measured against clear objectives. Domain experts review every draft for clarity and cultural sensitivity. After small-scale trials, we refine the wording based on observed results and community feedback, repeating this process until the prompt reliably assesses the intended construct.
+
+**Example**
+
+> *Sensing:* "Describe how you would recognize signs of frustration during a customer support chat."
+
+The example above demonstrates how a single prompt targets the Sensing construct. Expert reviewers validate that it references relevant emotional cues, and we iteratively adjust the phrasing after testing with different models to remove ambiguity or bias.

--- a/docs/research.html
+++ b/docs/research.html
@@ -24,6 +24,7 @@
                     </ul>
                 </li>
                 <li><a href="expert-collaborators.html">Collaborators</a></li>
+                <li><a href="prompt-development.html">Evaluation Prompt Development</a></li>
                 <li><a href="https://github.com/maxaeon/EQ-bench">GitHub Repository</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
## Summary
- document evaluation prompt development
- link to the new docs from the main site navigation

## Testing
- `grep -n "Evaluation Prompt Development" -r docs/*.html`


------
https://chatgpt.com/codex/tasks/task_e_6850d478315083228ebf1b7eab6fed23