### PR TITLE
Update license header and fix README link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,7 @@
+## License
+MIT License  
+© 2025 Max Parks
+
 MIT License
 
 Copyright (c) 2025 Max Parks

--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) and our [CODE_OF_CONDUCT.md](CODE
 </p>
 
 ## License
-- **Code and documentation**: Released under the [MIT License](LICENSE.md). See [LICENSE-NOTES.md](LICENSE-NOTES.md) for details on the private evaluation rubric.
+- **Code and documentation**: Released under the [MIT License](LICENSE.md).


### PR DESCRIPTION
## Summary
- add MIT header info to LICENSE.md
- remove link to missing LICENSE-NOTES.md from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d93d54648322a6cf34a82abadddf