### PR TITLE
Clarify MIT licensing and update page footers

### DIFF
--- a/data/LICENSE_DATA
+++ b/data/LICENSE_DATA
@@ -1,4 +1,25 @@
-Proprietary Data License
+## License
+MIT License  
+© 2025 Max Parks
 
-The sample data are made available for evaluation and internal research purposes only.
-You may not redistribute or use them for commercial purposes without written permission.
+MIT License
+
+Copyright (c) 2025 Max Parks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/LICENSE_DOCS
+++ b/docs/LICENSE_DOCS
@@ -1,4 +1,25 @@
-Proprietary Documentation License
+## License
+MIT License  
+© 2025 Max Parks
 
-These documents are provided for personal evaluation and internal research only.
-No redistribution or commercial use is allowed without prior written permission.
+MIT License
+
+Copyright (c) 2025 Max Parks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/adapt.html
+++ b/docs/adapt.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/alternative-models.html
+++ b/docs/alternative-models.html
@@ -81,7 +81,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/axes.html
+++ b/docs/axes.html
@@ -115,7 +115,7 @@
         </section>
     </main>
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/expert-collaborators.html
+++ b/docs/expert-collaborators.html
@@ -51,7 +51,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/explain.html
+++ b/docs/explain.html
@@ -55,7 +55,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/extended.html
+++ b/docs/extended.html
@@ -61,7 +61,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="env.js"></script>
     <script src="script.js"></script>

--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -130,7 +130,7 @@
 
     </main>
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script>
 

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -102,7 +102,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script>
     let constructs = [];

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -85,7 +85,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script>
     let benchmarks = [];

--- a/docs/phase4.html
+++ b/docs/phase4.html
@@ -107,7 +107,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/docs/research.html
+++ b/docs/research.html
@@ -130,7 +130,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/respond.html
+++ b/docs/respond.html
@@ -52,7 +52,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>

--- a/docs/sense.html
+++ b/docs/sense.html
@@ -53,7 +53,7 @@
     </main>
 
     <footer>
-        <p>&copy; Max Parks</p>
+        <p>&copy; 2025</p>
     </footer>
     <script src="script.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- make docs and data licenses match the MIT license
- replace old footer text in HTML pages with "© 2025"
- keep license reference to MIT in README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dd52fa548322bce674bdcbbe7f32