### PR TITLE
Remove Supabase references from docs

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -49,7 +49,7 @@
         <section id="literature">
             <hr>
             <h2>Relevant Literature</h2>
-<p>Notice something missing? Use the <strong>Add Source</strong> button to submit new references. Logged-in contributors may upload <code>.bib</code> or <code>.csv</code> files or paste either BibTeX or CSV text directly, and the entries will be saved to our Supabase database. Each submission must specify at least one of the supported SERA-X axes, a related construct, or the methodology it informs.</p>
+<p>Notice something missing? Use the <strong>Add Source</strong> button to submit new references. Logged-in contributors may upload <code>.bib</code> or <code>.csv</code> files or paste either BibTeX or CSV text directly, and the entries will be saved to the project backend. Each submission must specify at least one of the supported SERA-X axes, a related construct, or the methodology it informs.</p>
 <p>Need to modify the database structure itself? <a href="https://github.com/maxaeon/EQ-bench/issues/new?template=database-change.yml" target="_blank">Open a database change request</a>.</p>
             <div class="add-source-controls">
                 <button id="bibtex-btn" class="button" type="button">BibTeX/CSV</button>

--- a/docs/script.js
+++ b/docs/script.js
@@ -15,7 +15,7 @@ async function ensureSupabase() {
       return supabase;
     })
     .catch(err => {
-      console.error('Failed to load Supabase client', err);
+      console.error('Failed to load database client', err);
       supabasePromise = null;
       return null;
     });
@@ -355,7 +355,7 @@ async function fetchConstructs() {
 async function addConstruct(construct) {
   const client = await ensureSupabase();
   if (!client) {
-    const error = new Error('Supabase unavailable');
+    const error = new Error('Database unavailable');
     return { data: null, error };
   }
   const { data, error } = await client.from('constructs').insert([construct]);
@@ -368,7 +368,7 @@ async function addConstruct(construct) {
 async function updateConstruct(id, updates) {
   const client = await ensureSupabase();
   if (!client) {
-    const error = new Error('Supabase unavailable');
+    const error = new Error('Database unavailable');
     return { data: null, error };
   }
   const updateData = { ...updates };
@@ -406,7 +406,7 @@ async function fetchLiterature() {
 async function addLiterature(entry) {
   const client = await ensureSupabase();
   if (!client) {
-    const error = new Error('Supabase unavailable');
+    const error = new Error('Database unavailable');
     return { data: null, error };
   }
   const insertData = sanitizeLiteratureFields({ ...entry });
@@ -422,7 +422,7 @@ async function addLiterature(entry) {
 async function updateLiterature(id, updates) {
   const client = await ensureSupabase();
   if (!client) {
-    const error = new Error('Supabase unavailable');
+    const error = new Error('Database unavailable');
     return { data: null, error };
   }
   const updateData = sanitizeLiteratureFields({ ...updates });
@@ -460,7 +460,7 @@ async function fetchBenchmarks() {
 async function addBenchmark(entry) {
   const client = await ensureSupabase();
   if (!client) {
-    const error = new Error('Supabase unavailable');
+    const error = new Error('Database unavailable');
     return { data: null, error };
   }
   const { data, error } = await client.from('benchmarks').insert([entry]);


### PR DESCRIPTION
## Summary
- replace Supabase mention in Phase 1 instructions
- change script error messages to generic 'database' wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563ea513548322bbd145ea9b514c9e