### PR TITLE
Update construct category options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To support that goal we also explore several secondary questions:
 ## 1  Project Snapshot
 We are developing a collaborative benchmark for evaluating emotional intelligence in AI systems. This repository collects design documents and sample datasets as they become available. Authorized visitors can sign in using the **Login** button at the top right of the project website and submit new sources or constructs directly through the provided forms. Use the same button to log out when finished. These entries are stored in our project database tables (`literature` and `constructs`) and mirrored JSON files under `data/`. For guidance, see [docs/persisting_constructs.md](docs/persisting_constructs.md) and the [Research Hub Contribution Guide](docs/quick_github_guide.md).
 
+When adding a new entry, choose from **Psychology**, **Neuroscience**, **Computer Science**, or **Philosophy and Ethics** to keep categories consistent.
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/d25e1df5-df25-405d-a3b8-4424fc9f3408" width="600" alt="Image" />
 </p>

--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -421,7 +421,7 @@
             .forEach(a => axisF.appendChild(new Option(a.charAt(0).toUpperCase()+a.slice(1), a)));
 
         const fieldF = document.getElementById('lit-field-filter');
-        const fieldOrder = ['psychology','philosophy of mind','computer science','ethics','other'];
+        const fieldOrder = ['psychology','neuroscience','computer science','philosophy and ethics','other'];
         fieldOrder.forEach(f => {
             fieldF.appendChild(new Option(toTitle(f), f));
         });
@@ -596,9 +596,9 @@ async function startAddLit() {
         <label>URL: <input type="text" name="url"></label>
         <label>Category: <select name="category" multiple size="1">
             <option value="psychology">Psychology</option>
-            <option value="philosophy of mind">Philosophy of Mind</option>
+            <option value="neuroscience">Neuroscience</option>
             <option value="computer science">Computer Science</option>
-            <option value="ethics">Ethics</option>
+            <option value="philosophy and ethics">Philosophy and Ethics</option>
             <option value="other">Other</option>
         </select></label>
         <label>Keywords: <input type="text" name="keywords" placeholder="comma separated"></label>
@@ -743,9 +743,9 @@ async function startEditLit() {
         <label>URL: <input type="url" name="url" value="${item.url || ''}" placeholder="https://..."></label>
         <label>Category: <select name="category" multiple size="1">
             <option value="psychology" ${item.category && item.category.toLowerCase().includes('psychology') ? 'selected' : ''}>Psychology</option>
-            <option value="philosophy of mind" ${item.category && item.category.toLowerCase().includes('philosophy of mind') ? 'selected' : ''}>Philosophy of Mind</option>
+            <option value="neuroscience" ${item.category && item.category.toLowerCase().includes('neuroscience') ? 'selected' : ''}>Neuroscience</option>
             <option value="computer science" ${item.category && item.category.toLowerCase().includes('computer science') ? 'selected' : ''}>Computer Science</option>
-            <option value="ethics" ${item.category && item.category.toLowerCase().includes('ethics') ? 'selected' : ''}>Ethics</option>
+            <option value="philosophy and ethics" ${item.category && item.category.toLowerCase().includes('philosophy and ethics') ? 'selected' : ''}>Philosophy and Ethics</option>
             <option value="other" ${item.category && item.category.toLowerCase().includes('other') ? 'selected' : ''}>Other</option>
         </select></label>
         <label>Keywords: <input type="text" name="keywords" value="${Array.isArray(item.keywords) ? item.keywords.join(', ') : (item.keywords || '')}" placeholder="comma separated"></label>

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -127,7 +127,7 @@
             c.field = lowered.join(', ');
             c.category = lowered.join(', ');
         } else {
-            const fields = ['psychology','philosophy of mind','computer science','ethics'];
+            const fields = ['psychology','neuroscience','computer science','philosophy and ethics'];
             const foundFields = fields.filter(f => body.includes(f));
             c.field = foundFields.length ? foundFields.join(', ') : 'other';
             c.category = c.field;
@@ -335,7 +335,7 @@
                 .forEach(a => axisFilter.appendChild(new Option(a.charAt(0).toUpperCase()+a.slice(1), a)));
 
             const fieldFilter = document.getElementById('field-filter');
-            const fieldOrder = ['psychology','philosophy of mind','computer science','ethics','other'];
+            const fieldOrder = ['psychology','neuroscience','computer science','philosophy and ethics','other'];
             fieldOrder.forEach(f => {
                 fieldFilter.appendChild(new Option(toTitle(f), f));
             });
@@ -384,9 +384,9 @@ async function startAddConstruct() {
         <label>Potential Issues: <textarea name="verification_issues" rows="2"></textarea></label>
         <label>Category: <select name="category" multiple size="1">
             <option value="psychology">Psychology</option>
-            <option value="philosophy of mind">Philosophy of Mind</option>
+            <option value="neuroscience">Neuroscience</option>
             <option value="computer science">Computer Science</option>
-            <option value="ethics">Ethics</option>
+            <option value="philosophy and ethics">Philosophy and Ethics</option>
             <option value="other">Other</option>
         </select></label>
         <label>Related Literature: <select name="references" multiple size="1"></select></label>
@@ -478,9 +478,9 @@ async function startEditConstruct() {
         <label>Potential Issues: <textarea name="verification_issues" rows="2" placeholder="Verification caveats">${item.verification_issues || ''}</textarea></label>
         <label>Category: <select name="category" multiple size="1">
             <option value="psychology" ${item.category && item.category.toLowerCase().includes('psychology') ? 'selected' : ''}>Psychology</option>
-            <option value="philosophy of mind" ${item.category && item.category.toLowerCase().includes('philosophy of mind') ? 'selected' : ''}>Philosophy of Mind</option>
+            <option value="neuroscience" ${item.category && item.category.toLowerCase().includes('neuroscience') ? 'selected' : ''}>Neuroscience</option>
             <option value="computer science" ${item.category && item.category.toLowerCase().includes('computer science') ? 'selected' : ''}>Computer Science</option>
-            <option value="ethics" ${item.category && item.category.toLowerCase().includes('ethics') ? 'selected' : ''}>Ethics</option>
+            <option value="philosophy and ethics" ${item.category && item.category.toLowerCase().includes('philosophy and ethics') ? 'selected' : ''}>Philosophy and Ethics</option>
             <option value="other" ${item.category && item.category.toLowerCase().includes('other') ? 'selected' : ''}>Other</option>
         </select></label>
         <label>Related Literature: <select name="references" multiple size="1"></select></label>

--- a/sera_x_database_schema.md
+++ b/sera_x_database_schema.md
@@ -13,7 +13,7 @@ A construct represents a specific concept from the emotional intelligence litera
 | `definition` | text | Brief explanation of the construct. |
 | `axis_ids` | array | List of `axis_id` values that this construct informs. |
 | `references` | text | Citations or links supporting the construct. |
-| `category` | string | Broad discipline or topic area. |
+| `category` | string | Broad discipline or topic area. Use one of `Psychology`, `Neuroscience`, `Computer Science`, or `Philosophy and Ethics` (use `Other` only if none apply). |
 
 Example:
 


### PR DESCRIPTION
## Summary
- revise README instructions to list new categories
- update category dropdown values in Phase 1 and Phase 2 pages
- adjust filtering logic for updated labels
- document category list in the schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f1e01c4c8322bb34357edf3d159f