### PR TITLE
Update docs for Phase 2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
             The project maintains independent oversight. Our aim is to produce a gold standard EQ benchmark through unbiased, interdisciplinary collaboration.
           </p>
           <p>
-            We are currently in <strong>Phase 1</strong>: Initial literature review and first pass construct identification.
+            We are now in <strong>Phase 2</strong>: construct refinement and validation through interdisciplinary review.
           </p>
         </section>
 

--- a/docs/quick_github_guide.md
+++ b/docs/quick_github_guide.md
@@ -14,7 +14,7 @@ If you are unfamiliar with terms like "construct" or "axis," check the [Glossary
 1. Visit <https://maxaeon.github.io/EQ-bench/>.
 2. Click the **Login** button at the top right (or **Logout** when finished) and use the **Add Source** or **Add Construct** buttons to open the submission form.
 3. Fill in the requested details—be sure to provide at least one of the supported axes, a related construct, or the methodology it informs—and choose an **entry type** (article, book, etc.) before clicking **Save**. Use the **Add another author** button to list each author separately (up to ten).
-4. On the **Phase&nbsp;1** page you can upload your own `.bib` file or paste BibTeX text after logging in. The imported entries are saved directly to the repository's JSON files.
+4. On the **Phase&nbsp;2** page you can upload your own `.bib` file or paste BibTeX text after logging in. The imported entries are saved directly to the repository's JSON files.
 
 ## 2. Convert references to BibTeX
 
@@ -22,7 +22,7 @@ When filling out a literature issue or sharing your own bibliography, convert ea
 
 ## 3. Importing and exporting `.bib` files
 
-While logged in, you can upload a local `.bib` file or paste a BibTeX snippet on the **Phase&nbsp;1** page to quickly populate the submission form. If a record contains a `doi` field it is automatically converted to a `url` pointing at `https://doi.org/`. After importing, the site prompts you for any missing construct, axis, or methodology fields. Exported BibTeX files omit these extra fields so they remain compatible with standard reference managers. Maintainers can also run `python scripts/export_bibtex.py references.bib` to export the curated data directly from the JSON files.
+While logged in, you can upload a local `.bib` file or paste a BibTeX snippet on the **Phase&nbsp;2** page to quickly populate the submission form. If a record contains a `doi` field it is automatically converted to a `url` pointing at `https://doi.org/`. After importing, the site prompts you for any missing construct, axis, or methodology fields. Exported BibTeX files omit these extra fields so they remain compatible with standard reference managers. Maintainers can also run `python scripts/export_bibtex.py references.bib` to export the curated data directly from the JSON files.
 
 ## 4. Edit the literature review in Overleaf
 

--- a/docs/supabase_setup.md
+++ b/docs/supabase_setup.md
@@ -3,9 +3,9 @@ layout: default
 title: Supabase Setup
 ---
 
-# Supabase Setup
+# Supabase Setup (Legacy)
 
-This guide describes how to prepare your environment to seed the Supabase tables from the versioned JSON snapshots.
+**Note:** The project database now lives entirely in GitHub under the `data/` directory. Supabase is no longer required. The instructions below are kept for reference in case contributors need to migrate older snapshots.
 
 ## Node requirements
 

--- a/updates.md
+++ b/updates.md
@@ -8,3 +8,4 @@ A log of recent announcements and milestones for the AI EQ Research Hub.
 - **2025-05-29** – SERA-X dataset schema and preparation guide added.
 - **2025-05-29** – Evaluation rubric and dataset issue template published.
 - **2025-05-29** – Roadmap updated with repository references.
+- **2025-05-30** – Database migrated from Supabase to GitHub and Phase 2 kicked off.


### PR DESCRIPTION
## Summary
- note that the project is now in Phase 2 on the homepage
- update the quick GitHub guide to reference the Phase 2 page
- mark the Supabase setup guide as legacy and explain the GitHub database
- log the database migration in `updates.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2f9422f88322b535af83714aaeba