### PR TITLE
Remove supabase logic and open issue links

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -478,10 +478,8 @@
     }
 
 document.addEventListener('DOMContentLoaded', loadLiterature);
-let authed = false;
 
 async function startBibtex() {
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     const formHtml = `<form id="bibtex-form">
         <label>Upload .bib or .csv <input id="bibtex-file" type="file" accept=".bib,.csv"></label>
         <label>Or paste BibTeX/CSV:<br><textarea id="bibtex-text" rows="10" style="width:100%"></textarea></label>
@@ -537,7 +535,7 @@ async function startBibtex() {
             }
             obj.__index = ++maxIndex;
             let success = true;
-            if (authed && typeof addLiterature === 'function') {
+            if (typeof addLiterature === 'function') {
                 try {
                     const { data, error } = await addLiterature(obj);
                     if (error) {
@@ -567,7 +565,6 @@ async function startBibtex() {
 }
 
 async function startAddLit() {
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     document.getElementById('lit-add-row')?.remove();
     const tbody = document.querySelector('#lit-table tbody');
     const addRow = document.createElement('tr');
@@ -638,7 +635,6 @@ async function startAddLit() {
         e.preventDefault();
         errorDiv.textContent = '';
         errorDiv.style.display = 'none';
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         const axisArr = Array.from(form.elements.axis.selectedOptions).map(o => o.value);
         const catArr = Array.from(form.elements.category.selectedOptions).map(o => o.value);
         const constructVal = e.target.construct.value.trim();
@@ -713,7 +709,6 @@ async function startAddLit() {
 }
 
 async function startEditLit() {
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     if (selectedLitId === null) { showToast('Select an entry first.'); return; }
     const item = literature.find(l => (l.id ?? l.__index) == selectedLitId);
     if (!item) return;
@@ -781,7 +776,6 @@ async function startEditLit() {
     });
     form.addEventListener('submit', async e => {
         e.preventDefault();
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         if (!(await showConfirm('Save changes?'))) return;
         const before = JSON.parse(JSON.stringify(item));
         item.title = toTitleCase(form.title.value.trim());
@@ -839,7 +833,6 @@ async function deleteSelectedLit() {
     if (selectedLitId === null) { showToast('Select an entry first.'); return; }
     const idx = literature.findIndex(l => (l.id ?? l.__index) == selectedLitId);
     if (idx === -1) return;
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     if (!(await showConfirm('Delete this entry?'))) return;
     const item = literature[idx];
     if (item.id && typeof deleteLiterature === 'function') await deleteLiterature(item.id);

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -357,11 +357,9 @@
     }
 
 document.addEventListener('DOMContentLoaded', loadConstructs);
-let authed = false;
 let selectedConstructId = null;
 
 async function startAddConstruct() {
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     document.getElementById('construct-add-row')?.remove();
     const tbody = document.querySelector('#construct-table tbody');
     const addRow = document.createElement('tr');
@@ -405,7 +403,6 @@ async function startAddConstruct() {
         e.preventDefault();
         errorDiv.textContent = '';
         errorDiv.style.display = 'none';
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         const axesArr = Array.from(form.elements.axes.selectedOptions).map(o => o.value);
         const refsArr = Array.from(form.elements.references.selectedOptions).map(o => o.value);
         const catArr = Array.from(form.elements.category.selectedOptions).map(o => o.value);
@@ -455,7 +452,6 @@ async function startAddConstruct() {
 
 
 async function startEditConstruct() {
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     if (selectedConstructId === null) { showToast('Select an entry first.'); return; }
     const item = constructs.find(c => (c.id ?? c.__index) == selectedConstructId);
     if (!item) return;
@@ -495,7 +491,6 @@ async function startEditConstruct() {
     populateLiteratureSelect(form.elements.references, currentRefs);
     form.addEventListener('submit', async e => {
         e.preventDefault();
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         if (!(await showConfirm('Save changes?'))) return;
         const axesArr = Array.from(form.elements.axes.selectedOptions).map(o => o.value);
         const refsArr = Array.from(form.elements.references.selectedOptions).map(o => o.value);
@@ -537,7 +532,6 @@ async function deleteSelectedConstruct() {
     if (selectedConstructId === null) { showToast('Select an entry first.'); return; }
     const idx = constructs.findIndex(c => (c.id ?? c.__index) == selectedConstructId);
     if (idx === -1) return;
-    if (!authed) { if (!(await authenticate())) return; authed = true; }
     if (!(await showConfirm('Delete this construct?'))) return;
     const item = constructs[idx];
     if (item.id && typeof deleteConstruct === 'function') await deleteConstruct(item.id);

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -89,7 +89,6 @@
     <script>
     let benchmarks = [];
     let constructs = [];
-    let authed = false;
     let selectedBenchmarkId = null;
     let lastBmAction = null;
 
@@ -151,7 +150,6 @@
     document.addEventListener('DOMContentLoaded', loadBenchmarks);
 
     async function startAddBenchmark() {
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         document.getElementById('benchmark-add-row')?.remove();
         const tbody = document.querySelector('#benchmark-table tbody');
         const row = document.createElement('tr');
@@ -219,7 +217,6 @@
     }
 
     async function startEditBenchmark() {
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         if (selectedBenchmarkId === null) { showToast('Select an entry first.'); return; }
         const item = benchmarks.find(b => (b.id ?? b.__index) == selectedBenchmarkId);
         if (!item) return;
@@ -274,7 +271,6 @@
         if (selectedBenchmarkId === null) { showToast('Select an entry first.'); return; }
         const idx = benchmarks.findIndex(b => (b.id ?? b.__index) == selectedBenchmarkId);
         if (idx === -1) return;
-        if (!authed) { if (!(await authenticate())) return; authed = true; }
         if (!(await showConfirm('Delete this benchmark?'))) return;
         const item = benchmarks[idx];
         if (item.id && typeof deleteBenchmark === 'function') await deleteBenchmark(item.id);


### PR DESCRIPTION
## Summary
- drop old Supabase auth and DB helpers
- add `openGithubIssue` helper to open prefilled issue links
- switch CRUD helpers to open GitHub issues instead of touching Supabase
- remove authentication checks from phase pages

## Testing
- `pytest -q`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_686c3d9f2680832299f4f4d36c56b5ce