### PR TITLE
Handle blocked pop‑ups when creating GitHub issues

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -803,23 +803,26 @@ async function startEditLit() {
         item.axis = axisArr.join(', ');
         item.methodology_supported = form.methodology_supported.value;
         item.relevance = form.relevance.value;
-        if (item.id && typeof updateLiterature === 'function') await updateLiterature(item.id, {
-            title: item.title,
-            authors: item.authors,
-            year: item.year,
-            publisher: item.publisher,
-            journal: item.journal,
-            volume: item.volume,
-            number: item.number,
-            pages: item.pages,
-            url: item.url,
-            category: item.category,
-            keywords: item.keywords,
-            entry_type: item.entry_type,
-            axis: axisArr.join(', '),
-            methodology_supported: item.methodology_supported,
-            relevance: item.relevance
-        });
+        if (item.id && typeof updateLiterature === 'function') {
+            const { error } = await updateLiterature(item.id, {
+                title: item.title,
+                authors: item.authors,
+                year: item.year,
+                publisher: item.publisher,
+                journal: item.journal,
+                volume: item.volume,
+                number: item.number,
+                pages: item.pages,
+                url: item.url,
+                category: item.category,
+                keywords: item.keywords,
+                entry_type: item.entry_type,
+                axis: axisArr.join(', '),
+                methodology_supported: item.methodology_supported,
+                relevance: item.relevance
+            });
+            if (error) { showToast(error.message || error); return; }
+        }
         hideEditOverlay();
         applyLitFilters();
         showToast('Entry updated');
@@ -835,7 +838,10 @@ async function deleteSelectedLit() {
     if (idx === -1) return;
     if (!(await showConfirm('Delete this entry?'))) return;
     const item = literature[idx];
-    if (item.id && typeof deleteLiterature === 'function') await deleteLiterature(item.id);
+    if (item.id && typeof deleteLiterature === 'function') {
+        const { error } = await deleteLiterature(item.id);
+        if (error) { showToast(error.message || error); return; }
+    }
     const removed = literature.splice(idx,1)[0];
     selectedLitId = null;
     applyLitFilters();
@@ -847,15 +853,22 @@ async function undoLastLitAction() {
     if (!lastLitAction) { showToast('Nothing to undo'); return; }
     const { type, item, index, before } = lastLitAction;
     if (type === 'add') {
-        if (item.id && typeof deleteLiterature === 'function') await deleteLiterature(item.id);
+        if (item.id && typeof deleteLiterature === 'function') {
+            const { error } = await deleteLiterature(item.id);
+            if (error) { showToast(error.message || error); return; }
+        }
         const idx = literature.findIndex(l => l === item || (l.id ?? l.__index) == (item.id ?? item.__index));
         if (idx !== -1) literature.splice(idx,1);
     } else if (type === 'update') {
         Object.assign(item, before);
-        if (item.id && typeof updateLiterature === 'function') await updateLiterature(item.id, before);
+        if (item.id && typeof updateLiterature === 'function') {
+            const { error } = await updateLiterature(item.id, before);
+            if (error) { showToast(error.message || error); return; }
+        }
     } else if (type === 'delete') {
         if (typeof addLiterature === 'function') {
-            const { data } = await addLiterature(item);
+            const { data, error } = await addLiterature(item);
+            if (error) { showToast(error.message || error); return; }
             if (data && data[0]) item.id = data[0].id;
         }
         literature.splice(index,0,item);

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -508,19 +508,25 @@ async function startEditConstruct() {
         item.verification_issues = form.verification_issues.value;
         item.category = catArrEdit.join(', ');
         item.references = refsArr;
-        if (item.id && typeof updateConstruct === 'function') await updateConstruct(item.id, {
-            title: item.title,
-            axes: axesArr,
-            definition: item.definition,
-            example: item.example,
-            synonyms: item.synonyms,
-            related_terms: item.related_terms,
-            indicators: item.indicators,
-            measurement: item.measurement,
-            verification_issues: item.verification_issues,
-            category: item.category,
-            references: refsArr
-        });
+        if (item.id && typeof updateConstruct === 'function') {
+            const { error } = await updateConstruct(item.id, {
+                title: item.title,
+                axes: axesArr,
+                definition: item.definition,
+                example: item.example,
+                synonyms: item.synonyms,
+                related_terms: item.related_terms,
+                indicators: item.indicators,
+                measurement: item.measurement,
+                verification_issues: item.verification_issues,
+                category: item.category,
+                references: refsArr
+            });
+            if (error) {
+                showToast(error.message || error);
+                return;
+            }
+        }
         hideEditOverlay();
         applyConstructFilters();
         window.location.reload();
@@ -534,7 +540,10 @@ async function deleteSelectedConstruct() {
     if (idx === -1) return;
     if (!(await showConfirm('Delete this construct?'))) return;
     const item = constructs[idx];
-    if (item.id && typeof deleteConstruct === 'function') await deleteConstruct(item.id);
+    if (item.id && typeof deleteConstruct === 'function') {
+        const { error } = await deleteConstruct(item.id);
+        if (error) { showToast(error.message || error); return; }
+    }
     constructs.splice(idx,1);
     selectedConstructId = null;
     applyConstructFilters();

--- a/docs/phase3.html
+++ b/docs/phase3.html
@@ -250,7 +250,7 @@
             item.difficulty_level = parseInt(form.difficulty_level.value,10) || null;
             item.notes = form.notes.value;
             if (item.id && typeof updateBenchmark === 'function') {
-                await updateBenchmark(item.id, {
+                const { error } = await updateBenchmark(item.id, {
                     axis_id: item.axis_id,
                     construct_id: item.construct_id,
                     prompt: item.prompt,
@@ -258,6 +258,7 @@
                     difficulty_level: item.difficulty_level,
                     notes: item.notes
                 });
+                if (error) { showToast(error.message || error); return; }
             }
             hideEditOverlay();
             renderBenchmarks(benchmarks);
@@ -273,7 +274,10 @@
         if (idx === -1) return;
         if (!(await showConfirm('Delete this benchmark?'))) return;
         const item = benchmarks[idx];
-        if (item.id && typeof deleteBenchmark === 'function') await deleteBenchmark(item.id);
+        if (item.id && typeof deleteBenchmark === 'function') {
+            const { error } = await deleteBenchmark(item.id);
+            if (error) { showToast(error.message || error); return; }
+        }
         const removed = benchmarks.splice(idx,1)[0];
         selectedBenchmarkId = null;
         renderBenchmarks(benchmarks);
@@ -285,15 +289,22 @@
         if (!lastBmAction) { showToast('Nothing to undo'); return; }
         const { type, item, index, before } = lastBmAction;
         if (type === 'add') {
-            if (item.id && typeof deleteBenchmark === 'function') await deleteBenchmark(item.id);
+            if (item.id && typeof deleteBenchmark === 'function') {
+                const { error } = await deleteBenchmark(item.id);
+                if (error) { showToast(error.message || error); return; }
+            }
             const idx = benchmarks.findIndex(b => b === item || (b.id ?? b.__index) == (item.id ?? item.__index));
             if (idx !== -1) benchmarks.splice(idx,1);
         } else if (type === 'update') {
             Object.assign(item, before);
-            if (item.id && typeof updateBenchmark === 'function') await updateBenchmark(item.id, before);
+            if (item.id && typeof updateBenchmark === 'function') {
+                const { error } = await updateBenchmark(item.id, before);
+                if (error) { showToast(error.message || error); return; }
+            }
         } else if (type === 'delete') {
             if (typeof addBenchmark === 'function') {
-                const { data } = await addBenchmark(item);
+                const { data, error } = await addBenchmark(item);
+                if (error) { showToast(error.message || error); return; }
                 if (data && data[0]) item.id = data[0].id;
             }
             benchmarks.splice(index,0,item);

--- a/docs/script.js
+++ b/docs/script.js
@@ -133,7 +133,10 @@ function openGithubIssue(template, title, body) {
     '&title=' + encodeURIComponent(title) +
     '&body=' + encodeURIComponent(body);
   const win = window.open(url, '_blank');
-  if (!win) showToast('Unable to open GitHub issue.');
+  if (!win) {
+    showToast('Unable to open GitHub issue. Please check pop-up settings.');
+    return null;
+  }
   return win;
 }
 
@@ -213,26 +216,42 @@ async function fetchConstructs() {
 }
 
 async function addConstruct(construct) {
-  openGithubIssue(
+  const win = openGithubIssue(
     'construct.yml',
     'New construct: ' + (construct.title || ''),
     '```json\n' + JSON.stringify(construct, null, 2) + '\n```'
   );
+  if (!win)
+    return {
+      data: null,
+      error: 'Unable to open GitHub issue. Please check pop-up settings.'
+    };
   return { data: null, error: null };
 }
 
 async function updateConstruct(id, updates) {
   const updateData = { id, ...updates };
-  openGithubIssue(
+  const win = openGithubIssue(
     'construct.yml',
     'Update construct: ' + (updates.title || id),
     '```json\n' + JSON.stringify(updateData, null, 2) + '\n```'
   );
+  if (!win)
+    return {
+      data: null,
+      error: 'Unable to open GitHub issue. Please check pop-up settings.'
+    };
   return { data: null, error: null };
 }
 
 async function deleteConstruct(id) {
-  openGithubIssue('delete-construct.yml', 'Delete construct: ' + id, 'ID: ' + id);
+  const win = openGithubIssue(
+    'delete-construct.yml',
+    'Delete construct: ' + id,
+    'ID: ' + id
+  );
+  if (!win)
+    return { error: 'Unable to open GitHub issue. Please check pop-up settings.' };
   return null;
 }
 
@@ -241,25 +260,41 @@ async function fetchLiterature() {
 }
 
 async function addLiterature(entry) {
-  openGithubIssue(
+  const win = openGithubIssue(
     'reference.yml',
     'New reference: ' + (entry.title || ''),
     '```json\n' + JSON.stringify(entry, null, 2) + '\n```'
   );
+  if (!win)
+    return {
+      data: null,
+      error: 'Unable to open GitHub issue. Please check pop-up settings.'
+    };
   return { data: null, error: null };
 }
 
 async function updateLiterature(id, updates) {
-  openGithubIssue(
+  const win = openGithubIssue(
     'reference.yml',
     'Update reference: ' + (updates.title || id),
     '```json\n' + JSON.stringify({ id, ...updates }, null, 2) + '\n```'
   );
+  if (!win)
+    return {
+      data: null,
+      error: 'Unable to open GitHub issue. Please check pop-up settings.'
+    };
   return { data: null, error: null };
 }
 
 async function deleteLiterature(id) {
-  openGithubIssue('delete-publication.yml', 'Delete publication: ' + id, 'ID: ' + id);
+  const win = openGithubIssue(
+    'delete-publication.yml',
+    'Delete publication: ' + id,
+    'ID: ' + id
+  );
+  if (!win)
+    return { error: 'Unable to open GitHub issue. Please check pop-up settings.' };
   return null;
 }
 
@@ -268,25 +303,38 @@ async function fetchBenchmarks() {
 }
 
 async function addBenchmark(entry) {
-  openGithubIssue(
+  const win = openGithubIssue(
     'dataset-submission.yml',
     'New benchmark entry',
     '```json\n' + JSON.stringify(entry, null, 2) + '\n```'
   );
+  if (!win)
+    return {
+      data: null,
+      error: 'Unable to open GitHub issue. Please check pop-up settings.'
+    };
   return { data: null, error: null };
 }
 
 async function updateBenchmark(id, updates) {
-  openGithubIssue(
+  const win = openGithubIssue(
     'dataset-submission.yml',
     'Update benchmark: ' + id,
     '```json\n' + JSON.stringify({ id, ...updates }, null, 2) + '\n```'
   );
+  if (!win)
+    return { error: 'Unable to open GitHub issue. Please check pop-up settings.' };
   return null;
 }
 
 async function deleteBenchmark(id) {
-  openGithubIssue('dataset-submission.yml', 'Delete benchmark: ' + id, 'ID: ' + id);
+  const win = openGithubIssue(
+    'dataset-submission.yml',
+    'Delete benchmark: ' + id,
+    'ID: ' + id
+  );
+  if (!win)
+    return { error: 'Unable to open GitHub issue. Please check pop-up settings.' };
   return null;
 }
 


### PR DESCRIPTION
## Summary
- check the return of `window.open` in `openGithubIssue`
- return an error from data helpers when issue creation fails
- show toast messages when update/delete helpers fail in the forms
- propagate errors to form error areas when adding entries

## Testing
- `pytest -q`
- `flake8 || true`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686c46da71fc83229a3fb5183fb178ea