### PR TITLE
Fix literature fetch path

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -382,7 +382,7 @@
                 try { lit = await fetchLiterature(); } catch(e) { console.error(e); lit = []; }
             }
         } else {
-            try { lit = await (await fetch('data/literature.json')).json(); } catch(e) { lit = []; }
+            try { lit = await (await fetch('../data/literature.json')).json(); } catch(e) { lit = []; }
         }
 
         literature = lit.map((l, i) => Object.assign({__index: i}, {

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -173,7 +173,7 @@
                 try { lit = await fetchLiterature(); } catch(e) { console.error(e); lit = []; }
             }
         } else {
-            try { lit = await (await fetch('data/literature.json')).json(); } catch(e) { lit = []; }
+            try { lit = await (await fetch('../data/literature.json')).json(); } catch(e) { lit = []; }
         }
         literatureCache = lit;
         return lit;


### PR DESCRIPTION
## Summary
- reference canonical `data/literature.json` in Phase pages

## Testing
- `node -e "fetch('http://localhost:8000/data/literature.json').then(r=>r.json()).then(d=>console.log('entries',d.length)).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_686dd8f799148322bbb8420138c96834