### PR TITLE
Fix relative path for literature fetch

### DIFF
--- a/docs/phase1.html
+++ b/docs/phase1.html
@@ -382,7 +382,7 @@
                 try { lit = await fetchLiterature(); } catch(e) { console.error(e); lit = []; }
             }
         } else {
-            try { lit = await (await fetch('../data/literature.json')).json(); } catch(e) { lit = []; }
+            try { lit = await (await fetch('data/literature.json')).json(); } catch(e) { lit = []; }
         }
 
         literature = lit.map((l, i) => Object.assign({__index: i}, {

--- a/docs/phase2.html
+++ b/docs/phase2.html
@@ -173,7 +173,7 @@
                 try { lit = await fetchLiterature(); } catch(e) { console.error(e); lit = []; }
             }
         } else {
-            try { lit = await (await fetch('../data/literature.json')).json(); } catch(e) { lit = []; }
+            try { lit = await (await fetch('data/literature.json')).json(); } catch(e) { lit = []; }
         }
         literatureCache = lit;
         return lit;


### PR DESCRIPTION
## Summary
- correct fetch path for literature data on Phases 1 and 2 pages

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_686e9c7a0f14832280cbffe8758010c9